### PR TITLE
Use create_before_destroy for launch_configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,13 +147,17 @@ resource "aws_security_group" "rabbitmq_nodes" {
 }
 
 resource "aws_launch_configuration" "rabbitmq" {
-  name                 = "rabbitmq"
+  name_prefix          = "rabbitmq"
   image_id             = "${data.aws_ami_ids.ami.ids[0]}"
   instance_type        = "${var.instance_type}"
   key_name             = "${var.ssh_key_name}"
   security_groups      = ["${aws_security_group.rabbitmq_nodes.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.profile.id}"
   user_data            = "${data.template_file.cloud-init.rendered}"
+  
+  lifecycle = {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_group" "rabbitmq" {


### PR DESCRIPTION
Motivation
----------
If the launch configuration changes, for example if the user data is modified, the new launch configuration must be created and applied to the auto scaling group before the old one may be destroyed.

Modifications
-------------
Use "name_prefix" instead of "name" for the launch configuration.

Set lifecycle of "create_before_destroy" to true.

Results
-------
User data can be modified and applied to the existing auto scaling group without errors.

The launch configuration will gain a random suffix, to avoid name conflicts.